### PR TITLE
build: set engine spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
           fetch-depth: 0
       - uses: pnpm/action-setup@v3
         with:
-          version: 9.0.4
+          version: 9.0.6
       - uses: actions/setup-node@v4
         with:
-          node-version: 21.7.1
+          node-version: 20.9.0
           cache: "pnpm"
       - run: pnpm install --frozen-lockfile
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,13 @@
     "type": "git",
     "url": "https://github.com/jaedeok0/react-semantic-flex"
   },
+  "packageManager": "pnpm@9.0.6",
+  "engines": {
+    "node": ">=20.9.0 <21.0.0"
+  },
+  "engineStrict": true,
   "scripts": {
+    "preinstall": "npx only-allow pnpm",
     "start": "nx run playground:serve",
     "prettify": "prettier --write \"packages/**/src/**/*.(ts|tsx|css|json)\"",
     "lint": "nx run-many -t lint --fix",


### PR DESCRIPTION
## 📝 Description

set engine spec.

## 🎯 Current behavior

it doesn't restrict not allowed engines, such as yarn, npm or not matching versions.

Issue Number: N/A

## 🚀 New behavior

restrict to use only the allowed engines.

## ⚠️ Is this a breaking change?

- [ ] Yes
- [x] No

> If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
