### PR TITLE
fix: build configuration and change compiler

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -67,6 +67,12 @@
       "cache": true,
       "dependsOn": ["^build"],
       "inputs": ["production", "^production"]
+    },
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/packages/{projectName}"
+      },
+      "dependsOn": ["build"]
     }
   },
   "release": {

--- a/packages/react-semantic-flex/project.json
+++ b/packages/react-semantic-flex/project.json
@@ -43,7 +43,8 @@
             "output": "."
           }
         ]
-      }
+      },
+      "dependsOn": ["test"]
     }
   }
 }

--- a/packages/react-semantic-flex/project.json
+++ b/packages/react-semantic-flex/project.json
@@ -32,7 +32,7 @@
         "entryFile": "packages/react-semantic-flex/src/index.ts",
         "external": ["react", "react-dom", "react/jsx-runtime"],
         "rollupConfig": "@nx/react/plugins/bundle-rollup",
-        "compiler": "babel",
+        "compiler": "tsc",
         "generateExportsField": true,
         "extractCss": false,
         "format": ["esm", "cjs"],


### PR DESCRIPTION
## 📝 Description

This pull request includes changes to the build configuration and compiler for the project.
The `nx-release-publish` configuration has been added to publish the build output instead of the source code.
Additionally, the compiler for the `react-semantic-flex` package has been changed from Babel to TypeScript for check types on build

## 🎯 Current behavior

The `nx-release-publish` command publish raw source code.

Issue Number: N/A

## 🚀 New behavior

The `nx-release-publish` command publish build output.

## ⚠️ Is this a breaking change?

- [ ] Yes
- [x] No

> If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
