### PR TITLE
feat: support attribute type narrowing by tagName

### DIFF
--- a/packages/react-semantic-flex/src/lib/DynamicTag.tsx
+++ b/packages/react-semantic-flex/src/lib/DynamicTag.tsx
@@ -1,22 +1,22 @@
-import { ForwardedRef, HTMLProps, forwardRef } from "react";
+import React, { ComponentPropsWithRef, ElementType, forwardRef } from "react";
+import { SemanticComponentProps } from "../types/semanticComponentProps";
+import { TagName } from "../types/tagName";
 
-import { createElement } from "react";
-
-export type TagName = keyof HTMLElementTagNameMap;
-export interface DynamicTagProps<T extends HTMLElement["tagName"] = "div">
-  extends HTMLProps<T> {
-  tagName?: T;
-}
+type DynamicTag = (<T extends TagName = "div">(
+  props: SemanticComponentProps<T>,
+) => React.ReactElement | null) & {
+  displayName?: string;
+};
 
 export const DynamicTag = forwardRef(
-  <T extends TagName = "div">(
-    props: DynamicTagProps<T>,
-    ref: ForwardedRef<HTMLElementTagNameMap[T]>,
+  <E extends ElementType = "div">(
+    { tagName, ...properties }: SemanticComponentProps<E>,
+    ref: ComponentPropsWithRef<E>["ref"],
   ) => {
-    const { tagName = "div", children, ...properties } = props;
+    const Tag = tagName || "div";
 
-    return createElement(tagName, { ...properties, ref }, children);
+    return <Tag {...properties} ref={ref} />;
   },
-);
+) as DynamicTag;
 
 DynamicTag.displayName = "DynamicTag";

--- a/packages/react-semantic-flex/src/lib/Flex.tsx
+++ b/packages/react-semantic-flex/src/lib/Flex.tsx
@@ -1,8 +1,16 @@
-import { CSSProperties, ForwardedRef, forwardRef, useMemo } from "react";
-import { DynamicTag, DynamicTagProps, TagName } from "./DynamicTag";
+import {
+  CSSProperties,
+  ComponentPropsWithRef,
+  ElementType,
+  forwardRef,
+  useMemo,
+} from "react";
+import { DynamicTag } from "./DynamicTag";
 
 import classNames from "classnames/bind";
 import styles from "./Flex.module.scss";
+import { SemanticComponentProps } from "../types/semanticComponentProps";
+import { TagName } from "../types/tagName";
 
 const cx = classNames.bind(styles);
 
@@ -24,11 +32,20 @@ export type SupportedFlexProperty = Pick<
   | "gap"
 >;
 
-type FlexProps<T extends TagName> = SupportedFlexProperty &
-  Omit<DynamicTagProps<T>, "ref">;
+type FlexProps<E extends ElementType> = Omit<
+  SemanticComponentProps<E>,
+  "style"
+> &
+  SupportedFlexProperty;
+
+type Flex = (<T extends TagName = "div">(
+  props: FlexProps<T>,
+) => React.ReactElement | null) & {
+  displayName?: string;
+};
 
 export const Flex = forwardRef(
-  <T extends TagName>(
+  <E extends ElementType>(
     {
       children,
       className,
@@ -47,8 +64,8 @@ export const Flex = forwardRef(
       justifyItems,
       justifySelf,
       ...rest
-    }: FlexProps<T>,
-    ref: ForwardedRef<HTMLElementTagNameMap[T]>,
+    }: Omit<SemanticComponentProps<E>, "style"> & SupportedFlexProperty,
+    ref: ComponentPropsWithRef<E>["ref"],
   ) => {
     const memoizedFlexProperty = useMemo<SupportedFlexProperty>(
       () =>
@@ -91,7 +108,7 @@ export const Flex = forwardRef(
     );
 
     return (
-      <DynamicTag
+      <DynamicTag<TagName>
         ref={ref}
         className={cx("flex", className)}
         style={memoizedFlexProperty}
@@ -101,6 +118,4 @@ export const Flex = forwardRef(
       </DynamicTag>
     );
   },
-);
-
-Flex.displayName = "Flex";
+) as Flex;

--- a/packages/react-semantic-flex/src/types/semanticComponentProps.ts
+++ b/packages/react-semantic-flex/src/types/semanticComponentProps.ts
@@ -1,0 +1,6 @@
+import { ComponentPropsWithRef, ElementType } from "react";
+
+export type SemanticComponentProps<T extends ElementType = "div"> =
+  ComponentPropsWithRef<T> & {
+    tagName?: T;
+  };

--- a/packages/react-semantic-flex/src/types/tagName.ts
+++ b/packages/react-semantic-flex/src/types/tagName.ts
@@ -1,0 +1,1 @@
+export type TagName = keyof React.JSX.IntrinsicElements;


### PR DESCRIPTION
## 📝 Description

This pull request adds support for attribute type narrowing by tagName in the `Flex` component.
These changes improve the flexibility and type safety of the codebase.

## 🎯 Current behavior

Even if you enter an attribute unrelated to tagName, a type error does not occur.

Issue Number: N/A

## 🚀 New behavior

A type error occurs if an attribute unrelated to the specified tagName is entered.

## ⚠️ Is this a breaking change?

- [ ] Yes
- [x] No

> If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
